### PR TITLE
Added project_id and run_id to compute-event data output

### DIFF
--- a/actions/compute-payload.go
+++ b/actions/compute-payload.go
@@ -99,8 +99,6 @@ func ComputeEvent(a cc.Action) error {
 	outputFileName := a.Attributes.GetStringOrFail(outputFileNameKey) //expected this is local - needs to agree with the payload output datasource name
 	//useKnowledgeUncertainty, err := strconv.ParseBool(a.Parameters.GetStringOrFail(useKnowledgeUncertaintyKey))
 	damageFunctionPath := a.Attributes.GetStringOrFail(damageFunctionPathKey) //expected this is local - needs to agree with the payload input datasource name
-	projectId := a.Attributes.GetStringOrFail(projectIdKey)
-	runId := a.Attributes.GetStringOrFail(runIdKey)
 
 	hpi := hazardproviders.HazardProviderInfo{}
 	if durationsExist {
@@ -167,6 +165,86 @@ func ComputeEvent(a cc.Action) error {
 		if err != nil {
 			log.Fatalf("Failed to initialize spatial result writer: %s\n", err)
 		}
+	}
+	defer rw.Close()
+
+	//compute results
+	//get boundingbox
+	fmt.Println("Getting bbox")
+	bbox, err := hp.HazardBoundary()
+	if err != nil {
+		log.Panicf("Unable to get the raster bounding box: %s", err)
+	}
+	fmt.Println(bbox.ToString())
+	sp.ByBbox(bbox, func(f consequences.Receptor) {
+		//ProvideHazard works off of a geography.Location
+		d, err2 := hp.Hazard(geography.Location{X: f.Location().X, Y: f.Location().Y})
+		//compute damages based on hazard being able to provide depth
+		if err2 == nil {
+			r, err3 := f.Compute(d)
+			r.Headers = append(r.Headers, "multihazard")
+			bytes, err := json.Marshal(d)
+			s := ""
+			if err == nil {
+				s = string(bytes)
+			}
+			r.Result = append(r.Result, s)
+			if err3 == nil {
+				rw.Write(r)
+			}
+		}
+	})
+	return nil
+}
+func ComputeEventChart(a cc.Action) error {
+	// get all relevant parameters for the Chart team
+	tablename := a.Attributes.GetStringOrFail(tablenameKey)
+	depthGridPathString := a.Attributes.GetStringOrFail(depthgridDatasourceName)       // expected this is a vsis3 object
+	velocityGridPathString := a.Attributes.GetStringOrFail(velocitygridDatasourceName) // expected this is a vsis3 object
+
+	inventoryPath := a.Attributes.GetStringOrFail(inventoryPathKey) //expected this is local - needs to agree with the payload input datasource name
+	inventoryDriver := a.Attributes.GetStringOrFail(inventoryDriverKey)
+
+	outputDriver := a.Attributes.GetStringOrFail(outputDriverKey)
+	damageFunctionPath := a.Attributes.GetStringOrFail(damageFunctionPathKey) //expected this is local - needs to agree with the payload input datasource name
+	projectId := a.Attributes.GetStringOrFail(projectIdKey)
+	runId := a.Attributes.GetStringOrFail(runIdKey)
+
+	hpi := hazardproviders.HazardProviderInfo{
+		Hazards: []hazardproviders.HazardProviderParameterAndPath{{
+			Hazard:   hazards.Depth,
+			FilePath: depthGridPathString,
+		}, {
+			Hazard:   hazards.Velocity,
+			FilePath: velocityGridPathString,
+		}},
+	}
+	hp, err := hazardproviders.InitMulti(hpi)
+
+	sp, err := structureprovider.InitStructureProviderwithOcctypePath(inventoryPath, tablename, inventoryDriver, damageFunctionPath)
+	sp.SetDeterministic(true)
+	if err != nil {
+		return err
+	}
+	fmt.Sprintln(sp.FilePath)
+
+	//initalize a psql results writer
+	var rw consequences.ResultsWriter
+	pgUser := os.Getenv(pgUserKey)
+	pgPass := os.Getenv(pgPasswordKey)
+	pgDB := os.Getenv(pgDbnameKey)
+	pgHost := os.Getenv(pgHostKey)
+	pgPort := os.Getenv(pgPortKey)
+	pgSchema := os.Getenv(pgSchemaKey)
+
+	outConnStr := fmt.Sprintf(
+		"PG:dbname=%s user=%s password=%s host=%s port=%s schemas=%s",
+		pgDB, pgUser, pgPass, pgHost, pgPort, pgSchema,
+	)
+
+	rw, err = lrw.InitSpatialResultsWriter_PSQL(outConnStr, outputLayerName, outputDriver, pgDB)
+	if err != nil {
+		log.Fatalf("Failed to initialize spatial psql result writer: %s\n", err)
 	}
 	defer rw.Close()
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,9 @@ func main() {
 		case "compute-event":
 			actions.ComputeEvent(a)
 			break
+		case "compute-event-chart":
+			actions.ComputeEventChart(a)
+			break
 		case "compute-frequency":
 			actions.ComputeFrequencyEvent(a)
 			break

--- a/resultswriters/psql-spatial-results-writer.go
+++ b/resultswriters/psql-spatial-results-writer.go
@@ -13,7 +13,7 @@ import (
 
 // results writer for spatial data to psql database
 type psqlResultsWriter struct {
-	FilePath           string
+	ConnectionStr      string
 	LayerName          string
 	Layer              *gdal.Layer
 	ds                 *gdal.DataSource
@@ -143,10 +143,10 @@ func InitSpatialResultsWriter_PSQL(connStr string, layerName string, driver stri
 	newLayer := dsOut.LayerByName(layerName)
 
 	return &psqlResultsWriter{
-		FilePath:  connStr,
-		LayerName: layerName,
-		ds:        &dsOut,
-		Layer:     &newLayer,
-		index:     0,
+		ConnectionStr: connStr,
+		LayerName:     layerName,
+		ds:            &dsOut,
+		Layer:         &newLayer,
+		index:         0,
 	}, nil
 }


### PR DESCRIPTION
- Updated compute-event action to include project_id and run_id from attribute inputs into its data output. This will allow us to better organize and retrieve outputs from different runs of consequences-runner.